### PR TITLE
add status results

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,13 +59,14 @@ using Statistics
         tid0 = Vector{Int}(ones(n))
         x0 = 1 .+ [0:n-1;]*2.5 .+ 7.5
         y0 = 1 .+ [0:n-1;]*1.0 .+ 10.5
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test vtt.z == z # Check to see if the view is being written.
         @test count == fill(nt, n)
         @test tid == repeat([1:nt;]', 6)'
         @test mean(vx) == 1.0
         @test mean(vy) == 1.0
         @test size(count) == (n,)
+        @test size(status) == (n,)
         @test size(tid) == (ntrac+1, n)
         @test size(x) == (ntrac+1, n)
         @test size(y) == (ntrac+1, n)
@@ -77,32 +78,32 @@ using Statistics
 
 
         vtt.subgrid = true
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test 1.19 < mean(vx) < 1.21
         @test 1.19 < mean(vy) < 1.21
 
 
         vtt.min_contrast = 1.6
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test count !== fill(nt, n)
         vtt.min_contrast = -1.0
 
 
         vtt.score_method = "ncov"
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test 1.19 < mean(vx) < 1.21
         @test 1.19 < mean(vy) < 1.21
         vtt.score_method = "xcor"
 
 
         vtt.peak_inside_th = 0.03
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test count !== fill(nt, n)
         vtt.peak_inside_th = -1.0
 
 
         vtt.use_init_temp = true
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test 1.19 < mean(vx) < 1.21
         @test 1.19 < mean(vy) < 1.21
         vtt.use_init_temp = false
@@ -113,8 +114,9 @@ using Statistics
         x0 = reshape(x0, n1, n2)
         y0 = reshape(y0, n1, n2)
         tid0 = reshape(tid0, n1, n2)
-        count, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = VTTrac.trac(vtt, tid0, x0, y0, out_subimage=true, out_score_ary=true)
         @test size(count) == (n1, n2)
+        @test size(status) == (n1, n2)
         @test size(tid) == (ntrac+1, n1, n2)
         @test size(x) == (ntrac+1, n1, n2)
         @test size(y) == (ntrac+1, n1, n2)


### PR DESCRIPTION
### PR description
This PR adds a new result variable named `status` to distinguish why tracking has stopped.
The `status` has the same shape as `count` and contains a number from 0 to 9 for each tracking point.

Meanings of the numbers are follow:

* 0: Alive
* 1: Stop at `inspect_t_index` of `tidf`
* 2: Stop at `get_zsub_subgrid`
* 3: Stop at `min_contrast` check
* 4: Stop at `chk_zsub_peak_inside`
* 5: Stop at `inspect_t_index` of `tidl`
* 6: Stop at `get_score`
* 7: Stop at `find_score_peak`
* 8: Stop at `score_th0` or `score_th1` check
* 9: Stop at `chk_vchange`

### Note
These numbers are in order of implementation, so if a tracking point has a status number of `3`, the tracking may be stopped for other reasons after `3`.